### PR TITLE
Heat modelling changes for the built environment

### DIFF
--- a/lib/transformer/dataset_cast.rb
+++ b/lib/transformer/dataset_cast.rb
@@ -22,8 +22,8 @@ module Transformer
     end
 
     # Validation
-    validates_presence_of :number_of_residences
-    validates :number_of_residences, numericality: { greater_than: 0 }
+    validates_presence_of :number_of_inhabitants
+    validates :number_of_inhabitants, numericality: { greater_than: 0 }
 
     def atlas_attributes
       attributes.slice(*self.class.with_atlas_attributes(&:name))

--- a/lib/transformer/dataset_generator/scaler.rb
+++ b/lib/transformer/dataset_generator/scaler.rb
@@ -5,7 +5,7 @@ module Transformer
         Atlas::Scaler.new(
           cast.base_dataset,
           cast.area,
-          cast.number_of_residences
+          cast.number_of_inhabitants
         ).create_scaled_dataset
       end
 


### PR DESCRIPTION
Modelling of heat demand in the built environment has been updated. Summarized:

- Residences are set to four types: apartments, detached houses, semi-detached houses, terraced houses
- Residences are split into 6 construction periods: before 1945, 1945-1964, 1965-1984, 1985-2004, 2005 to present and future
- Buildings are split into 2 construction periods: present and future
- Useful space heating demand is no longer aggregated to a single node, but each residence of a certain type and construction period is connected to all heating technologies, the same goes for buildings
- Merit orders are added to determine allocation of technologies to residences
- Dataset initialisation (refinery and atlas) and required data (etdataset and etlocal) is updated
- Frontend charts, slides and sliders are updated
- Insulation has been changed, instead of setting a demand reduction, the typical useful demand of each residence and building can be adjusted
- Insulation costs queries are updated
- Useful demand can be assigned two different curves, depending on the technology one of the curves will be selected
- Deficits are calculated based on the capacity of the technology and the hourly demand of each residence and building

Goes with

- https://github.com/quintel/fever/pull/1
- https://github.com/quintel/refinery/pull/61
- https://github.com/quintel/atlas/pull/164
- https://github.com/quintel/etengine/pull/1386
- https://github.com/quintel/etsource/pull/2997
- https://github.com/quintel/etmodel/pull/4193
- https://github.com/quintel/etdataset/pull/989
- https://github.com/quintel/etlocal/pull/503