### PR TITLE
Bump atlas to f2e3f0d (httparty 0.24.0, activesupport 7.2.3.1)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ end
 
 gem 'rubel',    ref: '9fe7010', github: 'quintel/rubel'
 gem 'refinery', ref: '36b8e34', github: 'quintel/refinery'
-gem 'atlas',    ref: 'f0fb6be', github: 'quintel/atlas'
+gem 'atlas',    ref: 'f2e3f0d', github: 'quintel/atlas'
 
 group :development do
   gem 'rubocop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/quintel/atlas.git
-  revision: f0fb6bea437b69141eb8874b87f455fdeb803ba3
-  ref: f0fb6be
+  revision: f2e3f0de7a7fc9cd864fcf47ed3624c812803e83
+  ref: f2e3f0d
   specs:
     atlas (1.0.0)
       activemodel (>= 7)
@@ -39,9 +39,9 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (8.1.2.1)
-      activesupport (= 8.1.2.1)
-    activesupport (8.1.2.1)
+    activemodel (8.1.3)
+      activesupport (= 8.1.3)
+    activesupport (8.1.3)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.3.1)
@@ -148,7 +148,7 @@ GEM
     terminal-table (4.0.0)
       unicode-display_width (>= 1.1.1, < 4)
     thread_safe (0.3.6)
-    turbine-graph (0.1.3)
+    turbine-graph (0.1.4)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (3.2.0)


### PR DESCRIPTION
#### Context

Atlas is a core internal gem used by transformer, etlocal, etengine, and etsource. Two dependabot PRs were merged on atlas: httparty 0.21.0 → 0.24.0 and activesupport 7.0.7.1 → 7.2.3.1. This PR propagates those updates to transformer.

#### Implemented changes

- Bumped atlas ref from f0fb6be to f2e3f0d
- As a side effect, activesupport resolved to 8.1.2.1 and turbine was bumped to the latest version

## Checklist

- [x] I have tested these changes
- [ ] I have updated documentation as needed
- [x] I have tagged the relevant people for review
